### PR TITLE
Typo fixes for "preform" to "perform in 403 errors.

### DIFF
--- a/src/api/docs/achievements/achievementMethod.js
+++ b/src/api/docs/achievements/achievementMethod.js
@@ -41,6 +41,6 @@ class ErrorfulExample extends Example {
 
   httpCode() { return 403; }
   data() {
-    return "You are not permitted to preform that action.";
+    return "You are not permitted to perform that action.";
   }
 }

--- a/src/api/docs/channel/follow.js
+++ b/src/api/docs/channel/follow.js
@@ -34,7 +34,7 @@ class BadRequestResult extends Example {
 class ForbiddenActionResult extends Example {
   httpCode() { return 403; }
   description() { return "This will occur if you don't have permission on the requested user or the user attempts to follow its own channel."; }
-  data() { return "You are not permitted to preform that action."; }
+  data() { return "You are not permitted to perform that action."; }
 }
 
 class MissingResult extends Example {


### PR DESCRIPTION
Just two simple typo fixes.