### PR TITLE
Feature/remake nested types

### DIFF
--- a/src/rest/resource.pug
+++ b/src/rest/resource.pug
@@ -14,20 +14,11 @@ mixin typeDetails(typeName)
 
     if type.properties
         ul.rest-properties
-            for property, name in type.properties
+            for property, propertyName in type.properties
                 li
-                    -
-                        var ptype = property.type[0];
                     h5.title
-                        | #{property.name}
-                        //- The &nbsp; is used below rather than css-based
-                        //- spacing so that double clicking selects the
-                        //- property name without the type.
-                        small &nbsp;
-                            +typeNameString(property)
-
-                    if typeof property.description === 'string'
-                        p !{marked(property.description)}
+                        +simpleTypeHeading(propertyName, property)
+                +simpleType(propertyName, property)
 
 mixin method(method, resource)
     .modal.fade(tabindex='0' id=`${resource.uniqueId}_${method.method}`)

--- a/src/rest/resource.pug
+++ b/src/rest/resource.pug
@@ -10,7 +10,7 @@ mixin typeDetails(typeName)
         p.top-resource-description !{marked(type.description)}
     if type.example
         h4 Example:
-        pre= type.example
+        +typeExample(type)
 
     if type.properties
         ul.rest-properties

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -48,51 +48,29 @@ mixin typeNameString(type)
         | &gt;
     if !type.default && !type.required
         span.help(title='Optional') ?
-    if name === 'string' && (type.minLength || type.maxLength || type.pattern)
-        ul
-            if type.minLength
-                li
-                    span minLength: #{type.minLength}
-            if type.maxLength
-                li
-                    span maxLength: #{type.maxLength}
-            if type.pattern
-                li
-                    span pattern: #[pre.inline= type.pattern]
     if name === 'array' && type.items
-        ul
-            if type.minItems
-                li minItems: #{type.minItems}
-            if type.maxItems
-                li maxItems: #{type.maxItems}
-            if type.uniqueItems
-                li Items MUST be unique.
-            li items
-                - var parentType = type.items.type && type.items.type[0];
-                if parentType && !restUtil.isBaseType(parentType)
-                    = ' '
-                    small extends
-                        = ' '
-                        a(href=`#${parentType}`)= parentType
-                | :
-            if type.items.properties
-                li
-                    ul
-                        for property, propertyName in type.items.properties
-                            +simpleType(propertyName, property)
+        - var parentType = type.items.type && type.items.type[0];
+        if parentType && !restUtil.isBaseType(parentType)
+            = ' '
+            small extends
+                = ' '
+                a(href=`#${parentType}`)= parentType
+        | :
 mixin typeExample(type)
-    = log(typeof type.example)
     if typeof type.example === 'string'
         pre= type.example
     if typeof type.example === 'object'
         +highlightStr("json", JSON.stringify(type.example,null, 3))
 
-mixin describeSimpleType(key,type)
-    strong= restUtil.prettifyPropertyName(type.displayName || key)
+mixin simpleTypeHeading(key,type)
+    = restUtil.prettifyPropertyName(type.displayName || key)
     = ': '
     +typeNameString(type)
+
+mixin describeSimpleType(key,type)
     if type.description
-        | !{marked(type.description)}
+        if typeof type.description === 'string'
+            | !{marked(type.description)}
     if type.schema
         p
             strong Schema
@@ -106,15 +84,49 @@ mixin describeSimpleType(key,type)
             +typeExample(type)
 
 mixin simpleType(key, type, skipRequired)
+    +describeSimpleType(key,type)
+    //- based on the type of the type we can choose how to render its additional properties
     - rootType = restUtil.getRootType(type)
-    // rendering of scalar and 0.8 types
-    if rootType !== 'object'
-        li
-            +describeSimpleType(key,type)
-    else
-        li
-            +describeSimpleType(key,type)
-            if type.properties
-                ul
-                    for property, propertyName in type.properties
-                        +describeSimpleType(propertyName, property)
+    //- for strings check if we have min max and patterns
+    if rootType === 'string' && (type.minLength || type.maxLength || type.pattern)
+        //string
+        ul
+            if type.minLength
+                li
+                    span minLength: #{type.minLength}
+            if type.maxLength
+                li
+                    span maxLength: #{type.maxLength}
+            if type.pattern
+                li
+                    span pattern: #[pre.inline= type.pattern]
+    //- For arrays display min max etc, if the items have properties
+    //- display them using recursion
+    else if rootType === 'array'
+        //array
+        ul
+            if type.minItems
+                li minItems: #{type.minItems}
+            if type.maxItems
+                li maxItems: #{type.maxItems}
+            if type.uniqueItems
+                li Items MUST be unique.
+            li items
+            if type.items.properties
+                li
+                    ul
+                        for property, propertyName in type.items.properties
+                            li
+                                strong
+                                    +simpleTypeHeading(propertyName,property)
+                                +simpleType(propertyName, property)
+    //- for objects nest them together
+    else if rootType === 'object'
+        if type.properties
+            //nestin
+            ul
+                for property, propertyName in type.properties
+                    li
+                        strong
+                            +simpleTypeHeading(propertyName,property)
+                        +simpleType(propertyName, property)

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -1,3 +1,5 @@
+include ../mixins.pug
+
 mixin type(key, type, skipRequired)
     h4 Type:
         = ' '
@@ -57,10 +59,6 @@ mixin typeNameString(type)
             if type.pattern
                 li
                     span pattern: #[pre.inline= type.pattern]
-    if name === 'object' && type.properties
-        ul
-            for property, propertyName in type.properties
-                +simpleType(propertyName, property)
     if name === 'array' && type.items
         ul
             if type.minItems
@@ -82,29 +80,41 @@ mixin typeNameString(type)
                     ul
                         for property, propertyName in type.items.properties
                             +simpleType(propertyName, property)
+mixin typeExample(type)
+    = log(typeof type.example)
+    if typeof type.example === 'string'
+        pre= type.example
+    if typeof type.example === 'object'
+        +highlightStr("json", JSON.stringify(type.example,null, 3))
+
+mixin describeSimpleType(key,type)
+    strong= restUtil.prettifyPropertyName(type.displayName || key)
+    = ': '
+    +typeNameString(type)
+    if type.description
+        | !{marked(type.description)}
+    if type.schema
+        p
+            strong Schema
+            | :
+        pre
+            code= type.schema
+    if type.example
+        p
+            strong Example
+            | :
+            +typeExample(type)
 
 mixin simpleType(key, type, skipRequired)
     - rootType = restUtil.getRootType(type)
     // rendering of scalar and 0.8 types
     if rootType !== 'object'
         li
-            strong= restUtil.prettifyPropertyName(type.displayName || key)
-            = ': '
-            +typeNameString(type)
-            if type.description
-                | !{marked(type.description)}
-            if type.schema
-                p
-                    strong Schema
-                    | :
-                pre
-                    code= type.schema
-            if type.example
-                p
-                    strong Example
-                    | :
-                pre
-                    if type.type === 'string'
-                        = type.example
-                    else
-                        code= type.example
+            +describeSimpleType(key,type)
+    else
+        li
+            +describeSimpleType(key,type)
+            if type.properties
+                ul
+                    for property, propertyName in type.properties
+                        +describeSimpleType(propertyName, property)


### PR DESCRIPTION
We basically nest everything now, this means we don't exclude objects or avoid describing them.

I needed to do this because we were missing stuff that we had documented, throwing away documentation is not good

NEW:
![](https://i.probableprime.co.uk/u/r/OHaZDhjm6c.png)

OLD:
![](https://i.probableprime.co.uk/u/r/Yn665PGvzu.png)

I'm happy to restore the styling from the old type generator and/or discuss design changes here.