### PR TITLE
Added rate limiting table and displaying for endpoints

### DIFF
--- a/build/docs.js
+++ b/build/docs.js
@@ -10,25 +10,12 @@ const del = require('del');
 
 const fs = Bluebird.promisifyAll(require('fs'));
 const childProcess = Bluebird.promisifyAll(require('child_process'));
+const orderObject = require('./util').orderObject;
 
 // Function which returns the raml parser. We don't load this on require-time
 // since it has a lot of dependencies and slows down development builds when
 // unneeded.
 const ramlParser = () => require('raml-1-parser');
-
-/**
- * Creates a new object with all values from the passed object ordered by keys.
- * @param  {Object} obj
- * @return {Object}
- */
-function orderObject (obj) {
-    const ret = {};
-    const orderedKeys = Object.keys(obj).sort();
-    for (const key of orderedKeys) {
-        ret[key] = obj[key];
-    }
-    return ret;
-}
 
 /**
  * Ensures that the repo cloneable at the provided address is downloaded

--- a/build/misc.js
+++ b/build/misc.js
@@ -39,7 +39,7 @@ function getLocals () {
         liveEvents: require('../src/reference/liveloading/events'),
         chat: require('../src/reference/chat/data'),
         rest: readJSONFile(path.join(__dirname, '/tmp/raml-doc.json')),
-        beConfig: require(path.join(__dirname, '/tmp/backend/config/default.js')),
+        beConfig: require('./tmp/backend/config/default.js'),
         permissions: require('@mcph/beam-common').permissions,
         bsTabs: {},
         highlight: (lang, str) => {

--- a/build/util.js
+++ b/build/util.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * Creates a new object with all values from the passed object ordered by keys.
+ * @param  {Object} obj
+ * @return {Object}
+ */
+exports.orderObject = function orderObject (obj) {
+    const ret = {};
+    const orderedKeys = Object.keys(obj).sort();
+    for (const key of orderedKeys) {
+        ret[key] = obj[key];
+    }
+    return ret;
+};

--- a/src/rest/resource.pug
+++ b/src/rest/resource.pug
@@ -54,6 +54,12 @@ mixin method(method, resource)
                                         pre.oauth-scope= scope
                                 if securityScheme.description
                                     | !{marked(securityScheme.description)}
+                    if method.is
+                        - rateLimitInfo = restUtil.getTraitInfo(method, 'rateLimited')
+                        - console.log(rateLimitInfo)
+                        if rateLimitInfo
+                            .alert.alert-warning.
+                                This endpoint is rate-limited with the #[b= rateLimitInfo.bucket] bucket.
 
                     ul.nav.nav-tabs
                         -

--- a/src/rest/resource.pug
+++ b/src/rest/resource.pug
@@ -56,7 +56,6 @@ mixin method(method, resource)
                                     | !{marked(securityScheme.description)}
                     if method.is
                         - rateLimitInfo = restUtil.getTraitInfo(method, 'rateLimited')
-                        - console.log(rateLimitInfo)
                         if rateLimitInfo
                             .alert.alert-warning.
                                 This endpoint is rate-limited with the #[b= rateLimitInfo.bucket] bucket.

--- a/src/rest/template.pug
+++ b/src/rest/template.pug
@@ -11,6 +11,26 @@ include ./resource.pug
         include ../tutorials/rest_intro.pug
 
         p If you want some more information about talking to our REST API, check out our #[a(href='/tutorials/rest.html') REST Tutorial].
+        h2 Rate Limiting
+        p.
+            In order to garantuee API stability there are a few rate limits in place,
+            all endpoints that are rate limited have their #[code bucket] noted below.
+        p Here is a list of all rate limiting buckets and their attributes.
+        table.table.table-condensed
+            caption Each endpoint can be called #[code Request Count] times per #[code Time Interval].
+            thead
+                tr
+                    th Name
+                    th Request Count
+                    th Time Interval (in Seconds)
+            tbody
+                - orderered = orderObject(beConfig.ratelimit.buckets)
+                for bucket, name in orderered
+                    tr
+                        td= name
+                        td= bucket.max
+                        td= bucket.interval/1000
+
         include ../snippets/help.pug
         h2 Endpoints
         for resource in rest.resources


### PR DESCRIPTION
Caveats: This pulls the data from `default.js` which shouldn't make a different right now but might later, sadly `config` does not allow being instantiated with different working directories.

Pro: Automatic rate limit table building, YAY!

@connor4312 If you have a minute it would be totally cool if you could add a little `database` or `cache` icon to the endpoints (like the `lock` icon for secured endpoints), I didn't really understand how your glyph icon font thingy works 😛 

Requires: https://github.com/WatchBeam/backend/pull/859 to be merged to master to work correctly.