### PR TITLE
Fix/request response objects

### DIFF
--- a/src/rest/resource.pug
+++ b/src/rest/resource.pug
@@ -110,8 +110,12 @@ mixin method(method, resource)
                                         ul
                                             li #[strong Media Type]: #{key}
                                             if b.type
-                                                li #[strong Data Type]: #[+typeNameString(b)]
-
+                                                li
+                                                    strong Data Type
+                                                    | :
+                                                    = ' '
+                                                    +typeNameString(b)
+                                                    +simpleType(key, b)
                                         if b.schema
                                             p
                                                 strong Schema
@@ -143,19 +147,26 @@ mixin method(method, resource)
                                         h3 Body
                                         for b, key in response.body
                                             ul
-                                                li #[strong Media Type]: #{key}
+                                                li
+                                                    strong Media Type
+                                                    | :
+                                                    = ' '
+                                                    = key
                                                 if b.type
                                                     li
-                                                        strong Data Type:
+                                                        strong Data Type
+                                                        | :
+                                                        = ' '
                                                         +typeNameString(b)
+                                                        +simpleType(key, b)
                                             if b.schema
-                                                p
+                                                li
                                                     strong Schema
                                                     | :
                                                 pre
                                                     code= b.schema
                                             if b.example
-                                                p
+                                                li
                                                     strong Example
                                                     | :
                                                 pre

--- a/src/rest/resource.pug
+++ b/src/rest/resource.pug
@@ -75,11 +75,11 @@ mixin method(method, resource)
                                 tabsItems.response = 'Response';
                             }
 
-                        +bsTabs(`${resource.uniqueId}_tabs`, tabsItems)
+                        +bsTabs(`${resource.uniqueId}_${method.method}_tabs`, tabsItems)
 
                     .tab-content
                         if method.allUriParameters.length || method.queryParameters || method.headers || method.body
-                            +bsTabItem(`${resource.uniqueId}_tabs`, 'request')
+                            +bsTabItem(`${resource.uniqueId}_${method.method}_tabs`, 'request')
                                 if resource.allUriParameters.length
                                     h3 URI Parameters
                                     ul.rest-properties
@@ -125,7 +125,7 @@ mixin method(method, resource)
                                             pre
                                                 code b.example
                         if method.responses
-                            +bsTabItem(`${resource.uniqueId}_tabs`, 'response')
+                            +bsTabItem(`${resource.uniqueId}_${method.method}_tabs`, 'response')
                                 for response, key in method.responses
                                     h2: +statusCode(key)
                                     if (response.description)
@@ -161,7 +161,7 @@ mixin method(method, resource)
                                                 pre
                                                     code= b.example
                         if method.securedBy
-                            +bsTabItem(`${resource.uniqueId}_tabs`, 'security')
+                            +bsTabItem(`${resource.uniqueId}_${method.method}_tabs`, 'security')
                                 for securedBy in method.securedBy
                                     - securityScheme = restUtil.securitySchemeWithName(securedBy)
                                     h2

--- a/src/tutorials/channelid.pug
+++ b/src/tutorials/channelid.pug
@@ -1,5 +1,5 @@
 p.
     You can find your channel id by
     going to
-    #[a(href='https://beam.pro/api/v1/channels/username?fields=id') https://beam.pro/api/v1/channels/username?fields=id]
+    #[a(href='https://beam.pro/api/v1/channels/{username}?fields=id') https://beam.pro/api/v1/channels/username?fields=id]
     in your browser. Replacing username with your Beam username.


### PR DESCRIPTION
This updates how we render request and response bodies.

If they are an object we now drag them through the usual type system.
Before: 
![](https://i.probableprime.co.uk/u/r/ZCyAu0wSHK.png)
After:
![](https://i.probableprime.co.uk/u/r/JsQioljNQY.png)

We also add `_${method.method}` to all modal tabs. This fixes the modal tabs that sometimes got stuck. We had duplicate DOM ids floating around. 