### PR TITLE
FIx broken Python code in chat bot tutorial

### DIFF
--- a/src/tutorials/code/python/chat/1.py
+++ b/src/tutorials/code/python/chat/1.py
@@ -1,12 +1,12 @@
 # Address of the beam website.
 # No trailing slash.
-beam_addr = 'https://beam.pro'
+BEAM_ADDR = 'https://beam.pro'
 
 # Username of the account.
-username = 'username'
+USERNAME = 'username'
 
 # Password of the account.
-password = 'password'
+PASSWORD = 'password'
 
 # The id of the channel you want to connect to.
-channel = 12345
+CHANNEL = 12345

--- a/src/tutorials/code/python/chat/5.py
+++ b/src/tutorials/code/python/chat/5.py
@@ -6,7 +6,7 @@ from functools import partial
 
 
 if __name__ == "__main__":
-chat = create(config)
+    chat = create(config)
 
 # Tell chat to authenticate with the beam server. It'll throw
 # a chatty.errors.NotAuthenticatedError if it fails.


### PR DESCRIPTION
The Python section for the basic chat bot tutorial gives the code inside the config file as being lowercase, which won't work with the rest of the code/the framework. Later on in the code, `config.CHANNEL` is requested, which would always error because channel is lowercase in the config.

Additionally, all values required by [beam-client-python](https://github.com/WatchBeam/beam-client-python) are uppercase too, causing problems later on down the line. This PR converts the config variables in the tutorial to uppercase.