### PR TITLE
Feature/enable 3rd parties

### DIFF
--- a/build/misc.js
+++ b/build/misc.js
@@ -15,7 +15,19 @@ const orderObject = require('./util').orderObject;
  * @return {Object}
  */
 function readJSONFile (filePath) {
-    return JSON.parse(fs.readFileSync(filePath));
+    try {
+        return JSON.parse(fs.readFileSync(filePath));
+    } catch (e) {
+        return {};
+    }
+}
+
+function wrappedRequire(filepath) {
+    try {
+        return require(filepath);
+    } catch (e) {
+        return {};
+    }
 }
 
 /**
@@ -24,7 +36,7 @@ function readJSONFile (filePath) {
  * @return {Object}
  */
 function getLocals () {
-    const restDoc = require('./tmp/raml-doc.json');
+    const restDoc = readJSONFile(path.join(__dirname, '/tmp/raml-doc.json'));
     marked.setOptions({
         highlight (code) {
             return require('highlight.js').highlightAuto(code).value;
@@ -40,8 +52,8 @@ function getLocals () {
         libraries: require('./tmp/libraries'),
         liveEvents: require('../src/reference/constellation/events'),
         chat: require('../src/reference/chat/data'),
-        rest: readJSONFile(path.join(__dirname, '/tmp/raml-doc.json')),
-        beConfig: require('./tmp/backend/config/default.js'),
+        rest: restDoc,
+        beConfig: wrappedRequire('./tmp/backend/config/default.js'),
         permissions,
         permissionKeys,
         bsTabs: {},

--- a/build/misc.js
+++ b/build/misc.js
@@ -10,7 +10,8 @@ const _ = require('lodash');
 const orderObject = require('./util').orderObject;
 
 /**
- * Reads a json file
+ * Reads a json file, if there is a problem reading 
+ * the file return an empty Object
  * @param  {String} filePath
  * @return {Object}
  */
@@ -22,9 +23,15 @@ function readJSONFile (filePath) {
     }
 }
 
-function wrappedRequire (filepath) {
+/**
+ * Wraps a require so that if there is a problem reading
+ * the file it returns an empty object.
+ * @param {String} filePath
+ * @return {Object}
+ */
+function wrappedRequire (filePath) {
     try {
-        return require(filepath);
+        return require(filePath);
     } catch (e) {
         return {};
     }

--- a/build/misc.js
+++ b/build/misc.js
@@ -10,8 +10,8 @@ const _ = require('lodash');
 const orderObject = require('./util').orderObject;
 
 /**
- * Reads a json file, if there is a problem reading 
- * the file return an empty Object
+ * Reads a json file, if there is a problem reading
+ * the file it returns null.
  * @param  {String} filePath
  * @return {Object}
  */
@@ -19,13 +19,13 @@ function readJSONFile (filePath) {
     try {
         return JSON.parse(fs.readFileSync(filePath));
     } catch (e) {
-        return {};
+        return null;
     }
 }
 
 /**
  * Wraps a require so that if there is a problem reading
- * the file it returns an empty object.
+ * the file it returns null.
  * @param {String} filePath
  * @return {Object}
  */
@@ -33,7 +33,7 @@ function wrappedRequire (filePath) {
     try {
         return require(filePath);
     } catch (e) {
-        return {};
+        return null;
     }
 }
 

--- a/build/misc.js
+++ b/build/misc.js
@@ -22,7 +22,7 @@ function readJSONFile (filePath) {
     }
 }
 
-function wrappedRequire(filepath) {
+function wrappedRequire (filepath) {
     try {
         return require(filepath);
     } catch (e) {

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ You need to specify the `repos` section in the config such as this:
 
 ## Build
 Run `gulp` for a full build.
-Run `gulp recompile` for a build without JavaDoc and RAMLDoc.
+Run `gulp recompile` for a build without JavaDoc and RAMLDoc. This will also work for 3rd parties looking to contribute.
 Run `gulp watch` for development.
 
 ## Contribute

--- a/src/rest.pug
+++ b/src/rest.pug
@@ -7,13 +7,13 @@ block navbar
     .navbar-wrapper
         .container
             nav.navbar.navbar-inverse: +navbar()
-
-            h1
-                | #{rest.title} API documentation
-                if rest.version
-                    = ' '
-                    small version
-                        = ` ${rest.version}`
+            if rest
+                h1
+                    | #{rest.title} API documentation
+                    if rest.version
+                        = ' '
+                        small version
+                            = ` ${rest.version}`
 
 block content
     .container

--- a/src/rest/template.pug
+++ b/src/rest/template.pug
@@ -24,7 +24,7 @@ include ./resource.pug
                     th Request Count
                     th Time Interval (in Seconds)
             tbody
-                if beConfig.ratelimt && beConfig.ratelimt.buckets
+                if beConfig.ratelimit && beConfig.ratelimit.buckets
                     - orderered = orderObject(beConfig.ratelimit.buckets)
                     for bucket, name in orderered
                         tr

--- a/src/rest/template.pug
+++ b/src/rest/template.pug
@@ -24,12 +24,13 @@ include ./resource.pug
                     th Request Count
                     th Time Interval (in Seconds)
             tbody
-                - orderered = orderObject(beConfig.ratelimit.buckets)
-                for bucket, name in orderered
-                    tr
-                        td= name
-                        td= bucket.max
-                        td= bucket.interval/1000
+                if beConfig.ratelimt && beConfig.ratelimt.buckets
+                    - orderered = orderObject(beConfig.ratelimit.buckets)
+                    for bucket, name in orderered
+                        tr
+                            td= name
+                            td= bucket.max
+                            td= bucket.interval/1000
         h2(id='csrf') CSRF Tokens
         p.
             Beam's REST API requires the use of CSRF Tokens when using cookie-base authentication.
@@ -45,41 +46,44 @@ include ./resource.pug
 
         include ../snippets/help.pug
         h2 Endpoints
-        for resource in rest.resources
-            .panel.panel-default.panel-rest
-                a(name=resource.uniqueId id=resource.uniqueId)
-                a.panel-reference.icon.icon-link-1(href=`#${resource.uniqueId}`)
-                .panel-heading
-                    h3.panel-title= resource.displayName || resource.relativeUri
-                .panel-body
-                    if resource.description
-                        .top-resource-description!= marked(resource.description)
-                    .panel-group
-                        +resourceModals(resource)
-                        table(style='width:100%')
-                            tbody
-                                +resourceRows(resource)
+        if rest.resources
+            for resource in rest.resources
+                .panel.panel-default.panel-rest
+                    a(name=resource.uniqueId id=resource.uniqueId)
+                    a.panel-reference.icon.icon-link-1(href=`#${resource.uniqueId}`)
+                    .panel-heading
+                        h3.panel-title= resource.displayName || resource.relativeUri
+                    .panel-body
+                        if resource.description
+                            .top-resource-description!= marked(resource.description)
+                        .panel-group
+                            +resourceModals(resource)
+                            table(style='width:100%')
+                                tbody
+                                    +resourceRows(resource)
 
         h2 Models &amp; Types
-        for type, name in rest.types
-            .panel.panel-default.panel-rest
-                a(name=name id=name)
-                a.panel-reference.icon.icon-link-1(href=`#${name}`)
-                .panel-heading
-                    h3.panel-title= type.displayName
-                        - var parentType = type.type && type.type[0];
-                        if parentType && !restUtil.isBaseType(parentType)
-                            = ' '
-                            small extends
+        if rest.types
+            for type, name in rest.types
+                .panel.panel-default.panel-rest
+                    a(name=name id=name)
+                    a.panel-reference.icon.icon-link-1(href=`#${name}`)
+                    .panel-heading
+                        h3.panel-title= type.displayName
+                            - var parentType = type.type && type.type[0];
+                            if parentType && !restUtil.isBaseType(parentType)
                                 = ' '
-                                a(href=`#${parentType}`)= parentType
-                .panel-body
-                    +typeDetails(name)
+                                small extends
+                                    = ' '
+                                    a(href=`#${parentType}`)= parentType
+                    .panel-body
+                        +typeDetails(name)
 
     .col-md-3
         .hidden-print.rest-sidebar(role='complementary' style='padding:1px')
             h3 Endpoints
             nav
                 ul.nav.nav-stacked
-                    for r in rest.resources
-                        li: a(href=`#${r.uniqueId}`)= r.relativeUri
+                    if rest.resources
+                        for r in rest.resources
+                            li: a(href=`#${r.uniqueId}`)= r.relativeUri

--- a/src/rest/template.pug
+++ b/src/rest/template.pug
@@ -24,7 +24,7 @@ include ./resource.pug
                     th Request Count
                     th Time Interval (in Seconds)
             tbody
-                if beConfig.ratelimit && beConfig.ratelimit.buckets
+                if beConfig
                     - orderered = orderObject(beConfig.ratelimit.buckets)
                     for bucket, name in orderered
                         tr
@@ -46,7 +46,7 @@ include ./resource.pug
 
         include ../snippets/help.pug
         h2 Endpoints
-        if rest.resources
+        if rest
             for resource in rest.resources
                 .panel.panel-default.panel-rest
                     a(name=resource.uniqueId id=resource.uniqueId)
@@ -63,7 +63,7 @@ include ./resource.pug
                                     +resourceRows(resource)
 
         h2 Models &amp; Types
-        if rest.types
+        if rest
             for type, name in rest.types
                 .panel.panel-default.panel-rest
                     a(name=name id=name)
@@ -84,6 +84,6 @@ include ./resource.pug
             h3 Endpoints
             nav
                 ul.nav.nav-stacked
-                    if rest.resources
+                    if rest
                         for r in rest.resources
                             li: a(href=`#${r.uniqueId}`)= r.relativeUri


### PR DESCRIPTION
This just wraps requires that we do that might not exist should a user not have access to backend to return {}.

Then in the pug we just guard against blank objects with some conditionals.

3rd parties wishing to contribute can now just do `gulp recompile` followed by `gulp html-quick/watch` to build the tutorial and reference sections.