### PR TITLE
Correct pollstart docs

### DIFF
--- a/src/reference/chat/data.json
+++ b/src/reference/chat/data.json
@@ -413,7 +413,7 @@
       }
     },
     "PollStart": {
-      "description": "Sent when a new poll is started.",
+      "description": "Initially sent when a new poll is started. Then over the course of a poll it is re-sent with information about the polls progress.",
       "example": {
         "q": "How's the weather?",
         "answers": [


### PR DESCRIPTION
A bot dev was unaware this was the case and had a chat message fire on this event.

Led to some spam.

Should really be PollProgress for progress or something but we can look at that once the docs are correct.