### PR TITLE
filter all nodes by internal annotation, cleanup, fix simple typed array items not being rendered

### DIFF
--- a/build/docs.js
+++ b/build/docs.js
@@ -186,7 +186,7 @@ function filterRaml (node) {
             }
         }
         filterRaml(subNode);
-        // After filtering nodes may be empty, to prevent
+        // After filtering nodes may be empty
         if (_.isEmpty(subNode)) {
             if (_.isArray(node)) {
                 node.splice(index, 1);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint-json": "gulp lint-json",
     "test": "npm run lint && npm run lint-pug",
     "build": "gulp",
+    "rebuild": "gulp recompile",
     "start": "http-server -p 8000 dist",
     "watch": "gulp watch"
   },

--- a/src/rest/template.pug
+++ b/src/rest/template.pug
@@ -47,7 +47,7 @@ include ./resource.pug
         include ../snippets/help.pug
         h2 Endpoints
         if rest
-            for resource in rest.resources
+            for resource in orderObject(rest.resources)
                 .panel.panel-default.panel-rest
                     a(name=resource.uniqueId id=resource.uniqueId)
                     a.panel-reference.icon.icon-link-1(href=`#${resource.uniqueId}`)
@@ -64,7 +64,7 @@ include ./resource.pug
 
         h2 Models &amp; Types
         if rest
-            for type, name in rest.types
+            for type, name in orderObject(rest.types)
                 .panel.panel-default.panel-rest
                     a(name=name id=name)
                     a.panel-reference.icon.icon-link-1(href=`#${name}`)

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -38,7 +38,7 @@ mixin typeNameString(type)
             a(href=`#${name}`)= name
         else
             = name
-        | (#{type.enum.join(', ')})
+        != ` (${type.enum.map(val => `<code>${val}</code>`).join()})`
         if type.default
             span.help(title='Default Value')= `=${type.default}`
     else if union
@@ -139,10 +139,15 @@ mixin simpleType(key, type, skipRequired)
                 li Maximum length: #{type.maxItems}
             if type.uniqueItems
                 li Items MUST be unique.
-            li Item properties:
-                if type.items.properties
-                    ul.rest-nested-properties
-                        for property, propertyName in type.items.properties
-                            li
-                                +simpleTypeHeading(propertyName, property)
-                                +simpleType(propertyName, property)
+            if type.items.properties
+                li Item properties:
+                        ul.rest-nested-properties
+                            for property, propertyName in type.items.properties
+                                li
+                                    +simpleTypeHeading(propertyName, property)
+                                    +simpleType(propertyName, property)
+            else
+                li Item type:
+                    = ' '
+                    +typeNameString(type.items)
+

--- a/src/tutorials/code/node/interactive/2.js
+++ b/src/tutorials/code/node/interactive/2.js
@@ -10,7 +10,7 @@ beam.use('password', {
 .then(robot => setupRobotEvents(robot))
 .catch(err => {
     if (err.res) {
-        throw new Error('Error connecting to Interactive:' + err.res.body.mesage);
+        throw new Error('Error connecting to Interactive:' + err.res.body.message);
     }
     throw new Error('Error connecting to Interactive', err);
 });

--- a/src/tutorials/code/node/interactive/5.js
+++ b/src/tutorials/code/node/interactive/5.js
@@ -19,7 +19,7 @@ beam.use('password', {
 .then(robot => setupRobotEvents(robot))
 .catch(err => {
     if (err.res) {
-        throw new Error('Error connecting to Interactive:' + err.res.body.mesage);
+        throw new Error('Error connecting to Interactive:' + err.res.body.message);
     }
     throw new Error('Error connecting to Interactive', err);
 });


### PR DESCRIPTION
Simplified some logic by making the internal annotation universally filterable.
Reduced some functions pointlessly returning input values.
Updated some function docs.
Fixed item rendering for array types.
Moved some display logic (ordered objects) into the views.

Fixes: #130 