### PR TITLE
Add a config option to control java doc creation

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,9 @@
 # Whether the resulting build should be minified, or not.
 minify: false
 
+# Wether the reference docs should be built or not. Useful for local development
+buildReferenceDocs: true
+
 # Source and corresponding destination paths for resources. You should
 # probably not change these unless you know what you're doing:
 src:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,13 @@ require('./build/docs')(gulp, $);
 require('./build/misc')(gulp, $);
 require('./build/css')(gulp, $);
 
-gulp.task('default', ['html', 'js', 'css', 'images', 'java-doc']);
+const defaultTasks = ['html', 'js', 'css', 'images'];
+
+if (config.buildReferenceDocs) {
+    defaultTasks.push('java-doc');
+}
+
+gulp.task('default', defaultTasks);
 gulp.task('recompile', ['html-quick', 'js', 'css', 'images']);
 
 gulp.task('watch', () => {


### PR DESCRIPTION
I keep doing things similar to this locally it would be great to move it to config so that i dont keep having to accidentally check in a manual disable for it.